### PR TITLE
Adding nodeSelector and affinity to values so that it is possible to configure where the statefulset pods will get scheduled.

### DIFF
--- a/charts/libretranslate/templates/statefulset.yaml
+++ b/charts/libretranslate/templates/statefulset.yaml
@@ -301,9 +301,17 @@ spec:
           claimName: models-volume
       {{- end }}
       {{- end }}
+      {{- if .Values.affinity }}
+      affinity:
+      {{- toYaml .Values.affinity | nindent 8 }}
+      {{- end }}
+      {{- if .Values.nodeSelector }}
+      nodeSelector:
+      {{- toYaml .Values.nodeSelector | nindent 8 }}
+      {{- end }}
       {{- if .Values.tolerations }}
       tolerations:
-      {{- toYaml .Values.tolerations   | nindent 6 }}
+      {{- toYaml .Values.tolerations | nindent 6 }}
       {{- end }}
   {{- if and .Values.persistence.enabled (or (eq .Values.persistence.models.accessMode "ReadWriteOnce") (eq .Values.persistence.db.accessMode "ReadWriteOnce")) }}
   # still in beta, but this will allow us to delete the volumes when the statefulset is scaled down

--- a/charts/libretranslate/values.yaml
+++ b/charts/libretranslate/values.yaml
@@ -12,6 +12,12 @@ annotations: {}
 # Extra tolerations for pods
 tolerations: []
 
+# Node selectors for pods
+affinity: {}
+
+# Pod affinities
+nodeSelector: {}
+
 # Chart name override
 nameOverride: ""
 


### PR DESCRIPTION
Adding these values:
affinity: JSON object that is passed to the statefulset's affinity.
nodeSelector: JSON object that is passed to the statefulset's nodeSelector.