### PR TITLE
Feature: allow getting secret data from existing Kubernetes secrets

### DIFF
--- a/charts/libretranslate/Chart.yaml
+++ b/charts/libretranslate/Chart.yaml
@@ -6,4 +6,4 @@ sources:
   - https://github.com/LibreTranslate/LibreTranslate/
   - https://github.com/LibreTranslate/helm-chart/
 icon: https://libretranslate.com/static/favicon.ico
-version: 0.1.2
+version: 0.2.0

--- a/charts/libretranslate/templates/configmap.yaml
+++ b/charts/libretranslate/templates/configmap.yaml
@@ -30,8 +30,12 @@ data:
   debug: {{ .Values.appSettings.debug | squote }}
   ssl: {{ .Values.appSettings.ssl | squote }}
   apiKeys: {{ .Values.appSettings.apiKeys | squote }}
+  {{- if and (not .Values.appSettings.existingSecret) (not .Values.appSettings.secretKeys.origin) }}
   requireApiKeyOrigin: {{ .Values.appSettings.requireApiKeyOrigin | squote }}
+  {{- end }}
+  {{- if and (not .Values.appSettings.existingSecret) (not .Values.appSettings.secretKeys.secret) }}
   requireApiKeySecret: {{ .Values.appSettings.requireApiKeySecret | squote }}
+  {{- end }}
   suggestions: {{ .Values.appSettings.suggestions | squote }}
   disableFilesTranslation: {{ .Values.appSettings.disableFilesTranslation | squote }}
   disableWebUi: {{ .Values.appSettings.disableWebUi | squote }}

--- a/charts/libretranslate/templates/secret.yaml
+++ b/charts/libretranslate/templates/secret.yaml
@@ -1,3 +1,4 @@
+{{- if not .Values.adminUser.existingSecret }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -7,3 +8,4 @@ data:
   auth: {{ .Values.adminUser.auth | quote }}
   username: {{ .Values.adminUser.name | quote }}
   password: {{ .Values.adminUser.password | quote }}
+{{- end }}

--- a/charts/libretranslate/templates/statefulset.yaml
+++ b/charts/libretranslate/templates/statefulset.yaml
@@ -106,19 +106,31 @@ spec:
                   name: libretranslate-appsettings
                   key: apiKeys
             {{- end }}
-            {{- if and (.Values.appSettings.requireApiKeyOrigin) (ne .Values.appSettings.requireApiKeyOrigin "") }}
+            {{- if or .Values.appSettings.requireApiKeyOrigin .Values.appSettings.existingSecret }}
             - name: LT_REQUIRE_API_KEY_ORIGIN
               valueFrom:
+                {{- if not .Values.appSettings.existingSecret }}
                 configMapKeyRef:
                   name: libretranslate-appsettings
                   key: requireApiKeyOrigin
+                {{- else }}
+                secretKeyRef:
+                  name: {{ .Values.appSettings.existingSecret }}
+                  key: {{ .Values.appSettings.secretKeys.origin }}
+                {{- end }}
             {{- end }}
-            {{- if and (.Values.appSettings.requireApiKeySecret) (ne .Values.appSettings.requireApiKeySecret "") }}
+            {{- if and .Values.appSettings.requireApiKeySecret .Values.appSettings.existingSecret }}
             - name: LT_REQUIRE_API_KEY_SECRET
               valueFrom:
+                {{- if not .Values.appSettings.existingSecret }}
                 configMapKeyRef:
                   name: libretranslate-appsettings
                   key: requireApiKeySecret
+                {{- else }}
+                secretKeyRef:
+                  name: {{ .Values.appSettings.existingSecret }}
+                  key: {{ .Values.appSettings.secretKeys.secret }}
+                {{- end }}
             {{- end }}
             {{- if and (.Values.appSettings.suggestions) (ne .Values.appSettings.suggestions "") }}
             - name: LT_SUGGESTIONS

--- a/charts/libretranslate/values.yaml
+++ b/charts/libretranslate/values.yaml
@@ -127,6 +127,12 @@ adminUser:
   name: "YWRtaW4K"  # copy the username in base64 as a reference
   auth: "YWRtaW46JGFwcjEkYlpydmYvUFYkSHBHSlhqZU1EN0ZON2kyYndsMVRNMQoK"  # copy the output from the htpasswd command here as a reference
   password: "bXlTZWNyZXRQYXNzd29yZAo="  # copy the password as base64 for the admin user here as a reference
+  existingSecret: "" # use an existing secret for admin user
+  # key in existing secret
+  secretKeys:
+    name: "name"
+    auth: "auth"
+    password: "password"
 
 # Settings / Flags
 appSettings:
@@ -140,6 +146,12 @@ appSettings:
   disableWebUi:          "false"    # Disable web ui (Default: Web Ui enabled)
   updateModels:          "false"    # Update language models at startup (Default: Only on if no models found)
   metrics:               "false"    # Enable the /metrics endpoint for exporting Prometheus usage metrics (Default: Disabled)
+  existingSecret: "" # use an existing secret for api key origin and secret
+  # keys in existing secret
+  secretKeys:
+    apiKeyorigin: "origin"
+    apiKeysecret: "secret"
+
 
 # Configuration Parameters
 appConfig:


### PR DESCRIPTION
This allows users to use an existing Kubernetes Secret for both the admin user (currently not used in the StatefulSet), the API Key Origins, and API Key Secret. Here are the new values.yaml values:

```yaml
adminUser:
  existingSecret: "" # use an existing secret for admin user
  # key in existing secret
  secretKeys:
    name: "name"
    auth: "auth"
    password: "password"

appSettings:    
  existingSecret: "" # use an existing secret for api key origin and secret
  # keys in existing secret
  secretKeys:
    apiKeyorigin: "origin"
    apiKeysecret: "secret"
```

This would help with keeping plain text passwords outside of the values.yaml and instead have them fetched from Kubernetes Secrets.